### PR TITLE
ci: fix gcr container tag casing

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -61,4 +60,4 @@ jobs:
 
       - name: Build and push UI image
         run: |
-          yarn publish-pkgs -cp -r ${{ env.REGISTRY }} -o ${{ github.repository_owner }}
+          yarn publish-pkgs -cp -r ${{ env.REGISTRY }} -o $(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
This commit fixes the casing of container tags pushed to gcr.io, which requires that repository names be lowercase:

```sh
ERROR: invalid tag "ghcr.io/krumIO/ui-extension-krum-rancher-extensions-demo:0.1.0": repository name must be lowercase
```