### PR TITLE
feat: for APPLAUNCHER-6 added k8 annotations to global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 <h1 align="center">Krum Rancher Extensions Demo</h1>
 
+The App Launcher is intended to fill a large gap in functionality for non-operator users of Rancher.  Currently, if a user wants to access a software application running in Rancher/kubernetes, they need to dig deep into the services/ingress section in Rancher, or learn how to build the proxy URL or on their own. Otherwise, operators need to use an ingress to create convenient access for users.
+
+However, the proxy URL can be a powerful tool in Rancher. It allows a user with appropriate access to a namespaced resource to access that resource/application without ingress. 
+
+The App Launcher will expose a top-level directory of service/ingress objects, and pre-build proxy URLs. It will also provide an option to launch that ingress, if available.
+
 ## Setup
 
 ### Node
@@ -19,6 +25,14 @@ We use [corepack](https://nodejs.org/api/corepack.html) (comes with Node.js) to 
 corepack enable
 ```
 
-### Misc
+## Usage
+
+- To run the dev instance pointing at any given rancher installation locally you can use `API=<your rancher URI> yarn dev`
+- Global apps will show at the top as a combination of global apps defined by cluster YAML files and user-selected favorites
+ *note: global apps can be set by modifying the service's `metadata.annotations['extensions.applauncher/global-app']` to 'true'
+- Select different clusters to view the services of. Global Apps perisist across all views.
+- The view can be changed with the view buttons from grid to list views.
+
+## Misc
 
 For more info, refer to the [rancher extensions prerequisites](https://rancher.github.io/dashboard/extensions/extensions-getting-started#prerequisites).

--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ We use [corepack](https://nodejs.org/api/corepack.html) (comes with Node.js) to 
 corepack enable
 ```
 
-## Usage
-
-- To run the dev instance pointing at any given rancher installation locally you can use `API=<your rancher URI> yarn dev`
-- Global apps will show at the top as a combination of global apps defined by cluster YAML files and user-selected favorites
- *note: global apps can be set by modifying the service's `metadata.annotations['extensions.applauncher/global-app']` to 'true'
-- Select different clusters to view the services of. Global Apps perisist across all views.
-- The view can be changed with the view buttons from grid to list views.
-
 ## Misc
 
 For more info, refer to the [rancher extensions prerequisites](https://rancher.github.io/dashboard/extensions/extensions-getting-started#prerequisites).

--- a/pkg/app-launcher/README.md
+++ b/pkg/app-launcher/README.md
@@ -5,12 +5,18 @@ Rancher App Launcher Extension is a powerful tool for improved accessibility and
 ## How to Run
 
 1. Clone this repository to your machine.
-2. Install the npm dependencies using the command "yarn install".
-3. Run the extension with the command "API=<Rancher Backend URL> yarn dev".
+2. Install the npm dependencies using the command `yarn install`.
+3. Run the extension locally with the command `API=<Rancher Backend URL> yarn dev`.
 
 ## Usage
 
-Once the Rancher App Launcher Extension is installed, you can access a unified resource page from the main dashboard. This page showcases cards for each discovered service, allowing you to conveniently open the service with a simple click. The extension is designed to improve discoverability, and offer a straightforward way to navigate the complexities of multi-cluster environments.
+- Once the Rancher App Launcher Extension is installed, you can access a unified resource page from the main dashboard.
+- This page showcases cards for each discovered service and ingress, allowing you to conveniently open the service with a simple click.
+    *The extension is designed to improve discoverability, and offer a straightforward way to navigate the complexities of multi-cluster environments.*
+- Global apps will show at the top as a combination of global apps defined by cluster YAML files and user-selected favorites
+    *\*note: global apps can be set by modifying the service's `metadata.annotations['extensions.applauncher/global-app']` to 'true'*
+- Select different clusters to view the services of. Global Apps perisist across all views.
+- The view can be changed with the view buttons from grid to list views.
 
 ## Contribution
 

--- a/pkg/app-launcher/components/AppLauncherCard.vue
+++ b/pkg/app-launcher/components/AppLauncherCard.vue
@@ -109,6 +109,9 @@ export default {
           favoritedService.service.id === this.service.id
       );
     },
+    isGlobalApp() {
+      return this.service.metadata.annotations?.['extensions.applauncher/global-app'] === 'true';
+    },
   },
   name: 'AppLauncherCard',
   layout: 'plain',
@@ -143,22 +146,19 @@ export default {
       <p>{{ namespace }}/{{ name }}</p>
     </template>
     <template #actions>
-      <button class="icon-button" @click="toggleFavorite">
+      <button v-if="!isGlobalApp" class="icon-button" @click="toggleFavorite">
         <i :class="['icon', isFavorited ? 'icon-star' : 'icon-star-open']" />
       </button>
+      <i v-else class="icon icon-globe icon-only" />
       <a
         v-if="(endpoints?.length ?? 0) <= 1"
         :disabled="!endpoints?.length"
         :href="endpoints[0]?.value"
         target="_blank"
         rel="noopener noreferrer nofollow"
-        :title="
-          endpoints?.length === 0
-            ? t('appLauncher.noEndpointFoundForApp')
-            : t('appLauncher.launchEndpoint', {
-                endpoint: endpoints[0].label,
-              })
-        "
+        :title="endpoints?.length === 0 ? t('appLauncher.noEndpointFoundForApp') : t('appLauncher.launchEndpoint', {
+          endpoint: endpoints[0].label,
+        })"
         class="btn role-primary"
       >
         {{ t('appLauncher.launch') }}
@@ -185,5 +185,14 @@ export default {
   color: var(--primary);
   font-size: 1.8rem;
   margin-right: 1rem;
+}
+.icon-only {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--primary);
+  font-size: 1.8rem;
+  margin-right: 1rem;
+  margin-top: 0.5rem;
 }
 </style>

--- a/pkg/app-launcher/components/AppLauncherCard.vue
+++ b/pkg/app-launcher/components/AppLauncherCard.vue
@@ -2,6 +2,7 @@
 import { Card } from '@components/Card';
 import ButtonDropDown from '@shell/components/ButtonDropdown';
 import { isMaybeSecure } from '@shell/utils/url';
+import { ingressFullPath } from '@shell/models/networking.k8s.io.ingress';
 
 export default {
   components: {
@@ -19,46 +20,11 @@ export default {
     },
     service: {
       type: Object,
-      required: true,
-      default: () => ({
-        id: '',
-        metadata: {
-          labels: {
-            /**
-             * Helm chart name that created this app (if relevant).
-             */
-            'helm.sh/chart': '',
-            /**
-             * The component of the app.
-             *
-             * See `app.kubernetes.io/component` from:
-             * https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
-             */
-            'app.kubernetes.io/component': '',
-            /**
-             * The version of the app.
-             *
-             * See `app.kubernetes.io/version` from:
-             * https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
-             */
-            'app.kubernetes.io/version': '',
-          },
-          /**
-           * The name of the app.
-           *
-           * See `app.kubernetes.io/name` from:
-           * https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
-           */
-          name: '',
-          /**
-           * The namespace of the app.
-           */
-          namespace: '',
-        },
-        spec: {
-          ports: [],
-        },
-      }),
+      default: null,
+    },
+    ingress: {
+      type: Object,
+      default: null,
     },
   },
   methods: {
@@ -70,12 +36,15 @@ export default {
     },
   },
   computed: {
+    app() {
+      return this.service || this.ingress;
+    },
     endpoints() {
       return (
-        this.service?.spec.ports?.map((port) => {
+        this.service?.spec?.ports?.map((port) => {
           const endpoint = `${
             isMaybeSecure(port.port, port.protocol) ? 'https' : 'http'
-          }:${this.service.metadata.name}:${port.port}`;
+          }:${this.service?.metadata?.name}:${port.port}`;
 
           return {
             label: `${endpoint}${port.protocol === 'UDP' ? ' (UDP)' : ''}`,
@@ -86,32 +55,35 @@ export default {
     },
     computedServiceName() {
       return (
-        this.service?.metadata.labels?.['app.kubernetes.io/component'] ??
-        this.service?.metadata.name
+        this.service?.metadata?.labels?.['app.kubernetes.io/component'] ??
+        this.service?.metadata?.name
       );
     },
     helmChart() {
-      return this.service?.metadata.labels?.['helm.sh/chart'];
+      return this.service?.metadata?.labels?.['helm.sh/chart'];
     },
     kubernetesVersion() {
-      return this.service?.metadata.labels?.['app.kubernetes.io/version'];
+      return this.service?.metadata?.labels?.['app.kubernetes.io/version'];
     },
     name() {
-      return this.service?.metadata.name;
+      return this.service?.metadata?.name;
     },
     namespace() {
-      return this.service?.metadata.namespace;
+      return this.service?.metadata?.namespace;
     },
     isFavorited() {
       return this.favoritedServices.some(
         (favoritedService) =>
-          favoritedService.clusterId === this.clusterId &&
-          favoritedService.service.id === this.service.id
+          favoritedService?.clusterId === this.clusterId &&
+          favoritedService?.service?.id === this.service?.id
       );
     },
     isGlobalApp() {
-      return this.service.metadata.annotations?.['extensions.applauncher/global-app'] === 'true';
+      return this.service?.metadata?.annotations?.['extensions.applauncher/global-app'] === 'true';
     },
+    ingressPath() {
+      return ingressFullPath(this.ingress, this.ingress?.spec?.rules?.[0]);
+    }
   },
   name: 'AppLauncherCard',
   layout: 'plain',
@@ -123,27 +95,24 @@ export default {
     <template #title>
       <div style="width: 100%">
         <p style="font-size: 1.2rem">
-          {{ computedServiceName }}
+          {{ service ? service?.metadata?.name : ingress?.metadata?.name }}
         </p>
-        <div
-          style="
-            color: var(--input-label);
-            display: flex;
-            justify-content: space-between;
-            margin-top: 4px;
-          "
-        >
-          <p v-if="kubernetesVersion !== undefined">
+        <div style="color: var(--input-label); display: flex; justify-content: space-between; margin-top: 4px;">
+          <p v-if="app.type === 'service' && app.metadata?.labels?.['app.kubernetes.io/version'] !== undefined">
             {{ kubernetesVersion }}
           </p>
-          <p v-if="helmChart !== undefined">
+          <p v-if="app.type === 'service' && app.metadata?.labels?.['helm.sh/chart'] !== undefined">
             {{ helmChart }}
+          </p>
+          <p v-if="app.type === 'ingress'">
+            Ingress
           </p>
         </div>
       </div>
     </template>
     <template #body>
-      <p>{{ namespace }}/{{ name }}</p>
+      <p v-if="app.type === 'service'">{{ namespace }}/{{ name }}</p>
+      <p v-if="app.type === 'ingress'">{{ ingressPath }}</p>
     </template>
     <template #actions>
       <button v-if="!isGlobalApp" class="icon-button" @click="toggleFavorite">
@@ -151,7 +120,7 @@ export default {
       </button>
       <i v-else class="icon icon-globe icon-only" />
       <a
-        v-if="(endpoints?.length ?? 0) <= 1"
+        v-if="(endpoints?.length ?? 0) <= 1 && app.type === 'service'"
         :disabled="!endpoints?.length"
         :href="endpoints[0]?.value"
         target="_blank"
@@ -159,6 +128,15 @@ export default {
         :title="endpoints?.length === 0 ? t('appLauncher.noEndpointFoundForApp') : t('appLauncher.launchEndpoint', {
           endpoint: endpoints[0].label,
         })"
+        class="btn role-primary"
+      >
+        {{ t('appLauncher.launch') }}
+      </a>
+      <a
+        v-else-if="app.type === 'ingress'"
+        :href="ingressPath"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
         class="btn role-primary"
       >
         {{ t('appLauncher.launch') }}

--- a/pkg/app-launcher/components/AppLauncherCard.vue
+++ b/pkg/app-launcher/components/AppLauncherCard.vue
@@ -119,7 +119,7 @@ export default {
 </script>
 
 <template>
-  <Card :show-highlight-border="false" :sticky="true">
+  <Card class="app-launcher-card" :show-highlight-border="false" :sticky="true">
     <template #title>
       <div style="width: 100%">
         <p style="font-size: 1.2rem">
@@ -177,6 +177,12 @@ export default {
 <style lang="scss" scoped>
 @import "@shell/assets/styles/fonts/_icons.scss";
 
+.app-launcher-card {
+  ::v-deep .card-body {
+    overflow: hidden !important;
+  }
+}
+
 .icon-button {
   background: none;
   border: none;
@@ -186,6 +192,7 @@ export default {
   font-size: 1.8rem;
   margin-right: 1rem;
 }
+
 .icon-only {
   background: none;
   border: none;

--- a/pkg/app-launcher/pages/index.vue
+++ b/pkg/app-launcher/pages/index.vue
@@ -4,6 +4,7 @@ import Loading from '@shell/components/Loading';
 import SortableTable from '@shell/components/SortableTable';
 import ButtonDropDown from '@shell/components/ButtonDropdown';
 import { isMaybeSecure } from '@shell/utils/url';
+import { ingressFullPath } from '@shell/models/networking.k8s.io.ingress';
 
 import AppLauncherCard from '../components/AppLauncherCard.vue';
 
@@ -17,7 +18,7 @@ export default {
   data() {
     return {
       servicesByCluster: [],
-      mockServicesByCluster: [],
+      ingressesByCluster: [],
       clusterLoading: {},
       loading: true,
       selectedCluster: null,
@@ -59,19 +60,25 @@ export default {
   async mounted() {
     try {
       const allClusters = await this.getClusters();
+      console.log('allClusters', allClusters);
       this.servicesByCluster = await this.getServicesByCluster(allClusters);
+      this.ingressesByCluster = await this.getIngressesByCluster(allClusters);
+
+      console.log('servicesByCluster', this.servicesByCluster);
+      console.log('ingressesByCluster', this.ingressesByCluster);
+
+      console.log("ingress path", ingressFullPath(this.ingressesByCluster[1].ingresses[0], this.ingressesByCluster[1].ingresses[0].spec.rules?.[0]));
 
       // Set the first cluster as the selected cluster
       if (this.servicesByCluster.length > 0) {
         this.selectedCluster = this.servicesByCluster[0].id;
       }
       this.generateClusterOptions();
-      console.log('servicesByCluster', this.servicesByCluster);
 
       // Retrieve global apps based on annotations
       this.servicesByCluster.forEach((cluster) => {
         cluster.services.forEach((service) => {
-          if (service.metadata.annotations?.['extensions.applauncher/global-app'] === 'true') {
+          if (service.metadata?.annotations?.['extensions.applauncher/global-app'] === 'true') {
             this.favoritedServices.push({
               clusterId: cluster.id,
               service,
@@ -93,12 +100,10 @@ export default {
   },
   methods: {
     async getClusters() {
+      console.log('this.$store', this.$store);
       return await this.$store.dispatch(`management/findAll`, {
         type: MANAGEMENT.CLUSTER,
       });
-    },
-    async getMockServicesByCluster() {
-      return await Promise.resolve(mockServicesByCluster);
     },
     getClusterName(clusterId) {
       const cluster = this.servicesByCluster.find(c => c.id === clusterId);
@@ -113,7 +118,7 @@ export default {
           .filter((cluster) => cluster.isReady)
           .map(async (cluster) => {
             const clusterData = {
-              name: `${this.$store.getters['i18n/t']('nav.group.cluster')} ${cluster.spec.displayName}`,
+              name: cluster.spec.displayName,
               id: cluster.id,
               services: [],
               loading: true,
@@ -136,9 +141,38 @@ export default {
           })
       );
     },
+    async getIngressesByCluster(allClusters) {
+      return Promise.all(
+        allClusters
+          .filter((cluster) => cluster.isReady)
+          .map(async (cluster) => {
+            const clusterData = {
+              name: cluster.spec.displayName,
+              id: cluster.id,
+              ingresses: [],
+              loading: true,
+              error: false,
+            };
+            try {
+              const ingresses = (
+                await this.$store.dispatch('cluster/request', {
+                  url: `/k8s/clusters/${cluster.id}/v1/networking.k8s.io.ingresses`,
+                })
+              ).data;
+              clusterData.ingresses = ingresses;
+            } catch (error) {
+              console.error(`Error fetching ingresses for cluster ${cluster.id}:`, error);
+              clusterData.error = true;
+            } finally {
+              clusterData.loading = false;
+            }
+            return clusterData;
+          })
+      );
+    },
     generateClusterOptions() {
       this.clusterOptions = this.servicesByCluster.map((cluster) => ({
-        label: cluster.name.slice(8),
+        label: cluster.name,
         value: cluster.id,
       }));
     },
@@ -189,7 +223,59 @@ export default {
   },
   computed: {
     selectedClusterData() {
-      return this.getCluster(this.selectedCluster);
+      const cluster = this.getCluster(this.selectedCluster);
+      if (cluster) {
+        const ingresses = this.ingressesByCluster.find(
+          (ingressCluster) => ingressCluster.id === cluster.id
+        )?.ingresses || [];
+
+        const services = cluster.services.map((service) => {
+          const relatedIngress = ingresses.find((ingress) =>
+            ingress.spec.rules.some((rule) =>
+              rule.http.paths.some((path) =>
+                path.backend.service?.name === service.metadata.name
+              )
+            )
+          );
+          return {
+            ...service,
+            relatedIngress,
+          };
+        });
+
+        return {
+          ...cluster,
+          services,
+          ingresses,
+        };
+      }
+      return null;
+    },
+    sortedApps() {
+      if (this.selectedClusterData) {
+        const services = this.selectedClusterData.services.map((service) => ({
+          ...service,
+          type: 'service',
+          uniqueId: `service-${service.id}`,
+        }));
+
+        const ingresses = this.selectedClusterData.ingresses.map((ingress) => ({
+          ...ingress,
+          type: 'ingress',
+          uniqueId: `ingress-${ingress.id}`,
+        }));
+
+        return [...services, ...ingresses].sort((a, b) => {
+          const nameA = a.metadata.name.toLowerCase();
+          const nameB = b.metadata.name.toLowerCase();
+          if (this.tableHeaders[0].sortOrder === 'asc') {
+            return nameA.localeCompare(nameB);
+          } else {
+            return nameB.localeCompare(nameA);
+          }
+        });
+      }
+      return [];
     },
     sortedServices() {
       if (this.selectedClusterData) {
@@ -253,14 +339,22 @@ export default {
           <p>{{ $store.getters['i18n/t']('appLauncher.noServicesFound') }}</p>
         </template>
         <AppLauncherCard
-          v-else
-          v-for="service in sortedServices"
-          :key="service.id"
+          v-for="app in sortedApps"
+          :key="app.uniqueId"
           :cluster-id="selectedCluster"
-          :service="service"
+          :service="app.type === 'service' ? app : null"
+          :ingress="app.type === 'ingress' ? app : null"
           :favorited-services="favoritedServices"
           @toggle-favorite="toggleFavorite"
         />
+        <!-- <AppLauncherCard
+          v-for="ingress in selectedClusterData.ingresses"
+          :key="ingress.id"
+          :cluster-id="selectedCluster"
+          :ingress="ingress"
+          :favorited-services="favoritedServices"
+          @toggle-favorite="toggleFavorite"
+        /> -->
       </div>
       <div v-else-if="selectedView === 'list'">
         <SortableTable

--- a/pkg/app-launcher/pages/index.vue
+++ b/pkg/app-launcher/pages/index.vue
@@ -177,7 +177,7 @@ export default {
         });
       }
       // Store updated favorites in localStorage
-      localStorage.setItem('favoritedServices', JSON.stringify(this.favoritedServices));
+      localStorage.setItem('favoritedServices', JSON.stringify(this.favoritedServices.filter((s) => (s.service.metadata.annotations?.['extensions.applauncher/global-app'] !== 'true'))));
     },
     isFavorited(service, favoritedServices) {
       return favoritedServices.some(

--- a/pkg/app-launcher/pages/index.vue
+++ b/pkg/app-launcher/pages/index.vue
@@ -66,6 +66,25 @@ export default {
         this.selectedCluster = this.servicesByCluster[0].id;
       }
       this.generateClusterOptions();
+      console.log('servicesByCluster', this.servicesByCluster);
+
+      // Retrieve global apps based on annotations
+      this.servicesByCluster.forEach((cluster) => {
+        cluster.services.forEach((service) => {
+          if (service.metadata.annotations?.['extensions.applauncher/global-app'] === 'true') {
+            this.favoritedServices.push({
+              clusterId: cluster.id,
+              service,
+            });
+          }
+        });
+      });
+
+      // Retrieve favorites from localStorage
+      const storedFavorites = localStorage.getItem('favoritedServices');
+      if (storedFavorites) {
+        this.favoritedServices.push(...JSON.parse(storedFavorites));
+      }
     } catch (error) {
       console.error('Error fetching clusters', error);
     } finally {
@@ -119,7 +138,7 @@ export default {
     },
     generateClusterOptions() {
       this.clusterOptions = this.servicesByCluster.map((cluster) => ({
-        label: cluster.name,
+        label: cluster.name.slice(8),
         value: cluster.id,
       }));
     },
@@ -157,6 +176,8 @@ export default {
           service,
         });
       }
+      // Store updated favorites in localStorage
+      localStorage.setItem('favoritedServices', JSON.stringify(this.favoritedServices));
     },
     isFavorited(service, favoritedServices) {
       return favoritedServices.some(


### PR DESCRIPTION
In this screenshot the first global app, gets put there by metadata annotation and shows an unclickable globe. The next two are favorited. Also adds persistence of favorites via `localStorage`.
![image](https://github.com/krumIO/krum-rancher-extensions/assets/1085104/8f6a8fe0-f736-4a5a-a7b9-1caaa8f3b366)

Addresses:
- https://krumtest.atlassian.net/browse/APPLAUNCHER-6
- https://krumtest.atlassian.net/browse/APPLAUNCHER-17
- https://krumtest.atlassian.net/browse/APPLAUNCHER-24
- https://krumtest.atlassian.net/browse/APPLAUNCHER-27