### PR TITLE
feat: for APPLAUNCHER-34, APPLAUNCHER-32 filter changes

### DIFF
--- a/pkg/app-launcher/components/AppLauncherCard.vue
+++ b/pkg/app-launcher/components/AppLauncherCard.vue
@@ -91,7 +91,7 @@ export default {
 </script>
 
 <template>
-  <Card class="app-launcher-card" :show-highlight-border="false" :sticky="true">
+  <Card class="app-launcher-card" :show-highlight-border="false" :sticky="true" v-if="app">
     <template #title>
       <div style="width: 100%">
         <p style="font-size: 1.2rem">

--- a/pkg/app-launcher/pages/index.vue
+++ b/pkg/app-launcher/pages/index.vue
@@ -237,10 +237,19 @@ export default {
           };
         });
 
+        // return {
+        //   ...cluster,
+        //   services,
+        //   ingresses,
+        // };
+        
+        const filteredApps = this.filteredApps(services, ingresses);
+
         return {
           ...cluster,
           services,
           ingresses,
+          filteredApps,
         };
       }
       return null;
@@ -272,18 +281,30 @@ export default {
       return [];
     },
     filteredApps() {
-      if (this.searchQuery.trim() === '') {
-        return this.sortedApps;
-      } else {
-        const searchTerm = this.searchQuery.trim().toLowerCase();
-        return this.sortedApps.filter(app => {
-          return (app.metadata.name.toLowerCase().includes(searchTerm) ||
-            app.metadata.namespace.toLowerCase().includes(searchTerm) ||
-            app.metadata.labels?.['app.kubernetes.io/version']?.toLowerCase().includes(searchTerm) ||
-            app.metadata.labels?.['helm.sh/chart']?.toLowerCase().includes(searchTerm) ||
-            app.metadata.fields.includes(searchTerm));
+      return (services, ingresses) => {
+        const sortedApps = [...(services || []), ...(ingresses || {})].sort((a, b) => {
+          const nameA = a.metadata.name.toLowerCase();
+          const nameB = b.metadata.name.toLowerCase();
+          if (this.tableHeaders[0].sortOrder === 'asc') {
+            return nameA.localeCompare(nameB);
+          } else {
+            return nameB.localeCompare(nameA);
+          }
         });
-      }
+
+        if (this.searchQuery.trim() === '') {
+          return sortedApps;
+        } else {
+          const searchTerm = this.searchQuery.trim().toLowerCase();
+          return sortedApps.filter(app => {
+            return (app.metadata.name.toLowerCase().includes(searchTerm) ||
+              app.metadata.namespace.toLowerCase().includes(searchTerm) ||
+              app.metadata.labels?.['app.kubernetes.io/version']?.toLowerCase().includes(searchTerm) ||
+              app.metadata.labels?.['helm.sh/chart']?.toLowerCase().includes(searchTerm) ||
+              app.metadata.fields.includes(searchTerm));
+          });
+        }
+      };
     },
     sortedServices() {
       if (this.selectedClusterData) {
@@ -308,51 +329,49 @@ export default {
   <Loading v-if="loading" :label="$store.getters['i18n/t']('appLauncher.loading')" />
   <div v-else>
     <div v-if="favoritedServices.length > 0">
-      <h2>{{ t('appLauncher.globalApps') }}</h2>
+      <div class="cluster-header">
+        <h2>{{ t('appLauncher.globalApps') }}</h2>
+        <div class="cluster-actions">
+          <div class="search-input">
+            <input v-model="searchQuery" :placeholder="$store.getters['i18n/t']('appLauncher.filter')" />
+          </div>
+          <button class="icon-button" @click="toggleSortOrder" v-if="selectedView === 'grid'">
+            <i class="icon icon-sort" />
+          </button>
+          <div class="select-wrapper">
+            <select v-model="selectedCluster" class="cluster-select">
+              <option v-for="option in clusterOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </div>
+          <button class="icon-button" @click="selectedView = 'grid'">
+            <i class="icon icon-apps" />
+          </button>
+          <button class="icon-button" @click="selectedView = 'list'">
+            <i class="icon icon-list-flat" />
+          </button>
+        </div>
+      </div>
       <div class="services-by-cluster-grid">
-        <AppLauncherCard
-          v-for="favoritedService in favoritedServices"
-          :key="`${favoritedService.clusterId}-${favoritedService.service.id}`"
-          :cluster-id="favoritedService.clusterId"
-          :service="favoritedService.service"
-          :favorited-services="favoritedServices"
-          @toggle-favorite="toggleFavorite"
-        />
+        <AppLauncherCard v-for="favoritedService in favoritedServices"
+          :key="`${favoritedService.clusterId}-${favoritedService.service.id}`" :cluster-id="favoritedService.clusterId"
+          :service="favoritedService.service" :favorited-services="favoritedServices"
+          @toggle-favorite="toggleFavorite" />
       </div>
     </div>
     <div class="cluster-header">
-      <h1>{{ selectedCluster ? getClusterName(selectedCluster) : $store.getters['i18n/t']('appLauncher.selectCluster') }}</h1>
-      <div class="cluster-actions">
-        <button class="icon-button" @click="toggleSortOrder" v-if="selectedView === 'grid'">
-          <i class="icon icon-sort" />
-        </button>
-        <div class="select-wrapper">
-          <select v-model="selectedCluster" class="cluster-select">
-            <option v-for="option in clusterOptions" :key="option.value" :value="option.value">
-              {{ option.label }}
-            </option>
-          </select>
-        </div>
-        <button class="icon-button" @click="selectedView = 'grid'">
-          <i class="icon icon-apps" />
-        </button>
-        <button class="icon-button" @click="selectedView = 'list'">
-          <i class="icon icon-list-flat" />
-        </button>
-      </div>
+      <h1>
+        {{ selectedCluster ? getClusterName(selectedCluster) : $store.getters['i18n/t']('appLauncher.selectCluster') }}
+      </h1>
     </div>
     <div v-if="selectedCluster">
       <div v-if="selectedView === 'grid'">
-        <div class="search-input">
-          <input v-model="searchQuery" :placeholder="$store.getters['i18n/t']('appLauncher.filter')" />
-        </div>
         <div class="services-by-cluster-grid">
-          <template v-if="filteredApps.length === 0">
-            <p>{{ $store.getters['i18n/t']('appLauncher.noAppsFound') }}</p>
-          </template>
+          <p v-if="selectedClusterData.filteredApps.length === 0">{{ $store.getters['i18n/t']('appLauncher.noAppsFound') }}</p>
           <AppLauncherCard
-            v-else
-            v-for="app in filteredApps"
+            v-if="selectedClusterData.filteredApps.length !== 0"
+            v-for="app in selectedClusterData.filteredApps"
             :key="app.uniqueId"
             :cluster-id="selectedCluster"
             :service="app.type === 'service' ? app : null"
@@ -364,13 +383,13 @@ export default {
       </div>
       <div v-else-if="selectedView === 'list'">
         <SortableTable
-          :rows="sortedServices"
+          :rows="selectedClusterData.filteredApps"
           :headers="tableHeaders"
-          :row-key="'id'"
-          :search="true"
+          :row-key="'uniqueId'"
+          :search="false"
           :table-actions="false"
           :row-actions="false"
-          :no-rows-text="$store.getters['i18n/t']('appLauncher.noServicesFound')"
+          :no-rows-text="$store.getters['i18n/t']('appLauncher.noAppsFound')"
         >
           <template #cell:name="{row}">
             {{ row.metadata.name }}
@@ -389,22 +408,12 @@ export default {
               <button class="icon-button favorite-icon" @click="toggleFavorite(row)">
                 <i :class="['icon', isFavorited(row, favoritedServices) ? 'icon-star' : 'icon-star-open']" />
               </button>
-              <a
-                v-if="getEndpoints(row)?.length <= 1"
-                :href="getEndpoints(row)[0]?.value"
-                target="_blank"
-                rel="noopener noreferrer nofollow"
-                class="btn role-primary"
-              >
+              <a v-if="getEndpoints(row)?.length <= 1" :href="getEndpoints(row)[0]?.value" target="_blank"
+                rel="noopener noreferrer nofollow" class="btn role-primary">
                 {{ t('appLauncher.launch') }}
               </a>
-              <ButtonDropDown
-                v-else
-                :button-label="t('appLauncher.launch')"
-                :dropdown-options="getEndpoints(row)"
-                :title="t('appLauncher.launchAnEndpointFromSelection')"
-                @click-action="(o) => openLink(o.value)"
-              />
+              <ButtonDropDown v-else :button-label="t('appLauncher.launch')" :dropdown-options="getEndpoints(row)"
+                :title="t('appLauncher.launchAnEndpointFromSelection')" @click-action="(o) => openLink(o.value)" />
             </div>
           </template>
         </SortableTable>
@@ -462,7 +471,6 @@ export default {
 }
 
 .search-input {
-  margin-bottom: 1rem;
   text-align: right;
   justify-content: flex-end;
   display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14901,9 +14901,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"krum-rancher-extensions-demo@workspace:.":
+"krum-rancher-extensions@workspace:.":
   version: 0.0.0-use.local
-  resolution: "krum-rancher-extensions-demo@workspace:."
+  resolution: "krum-rancher-extensions@workspace:."
   dependencies:
     "@babel/plugin-proposal-private-property-in-object": ^7.21.11
     "@rancher/components": 0.1.3


### PR DESCRIPTION
Made the filter global between the grid and list view. Positioned it with other controls. Positioned all the controls above the global section. Made the controls sticky. Added All Clusters as default option.

Addresses:
- https://krumtest.atlassian.net/browse/APPLAUNCHER-34
- https://krumtest.atlassian.net/browse/APPLAUNCHER-32
- https://krumtest.atlassian.net/browse/APPLAUNCHER-33


Current:
![image](https://github.com/krumIO/krum-rancher-extensions/assets/1085104/ec73d5fd-0023-483a-a7b1-739e41bd9bc7)


┆Issue is synchronized with this [Jira Task](https://krumtest.atlassian.net/browse/APPLAUNCHER-36) by [Unito](https://www.unito.io)
