### PR TITLE
remove icon imports and bump shell version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.2.1-alpha.0",
-    "@rancher/shell": "0.5.2",
+    "@rancher/shell": "0.5.3",
     "@types/lodash": "4.14.184",
     "core-js": "3.21.1",
     "css-loader": "4.3.0"

--- a/pkg/app-launcher/components/AppLauncherCard.vue
+++ b/pkg/app-launcher/components/AppLauncherCard.vue
@@ -149,7 +149,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-@import "@shell/assets/styles/fonts/_icons.scss";
 
 .app-launcher-card {
   ::v-deep .card-body {

--- a/pkg/app-launcher/package.json
+++ b/pkg/app-launcher/package.json
@@ -1,14 +1,14 @@
 {
   "name": "app-launcher",
   "description": "App Launcher extension for Rancher",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/rancher-version": ">= 2.8.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0 < v2.9.0-0",
       "catalog.cattle.io/kube-version": ">= v1.16.0-0 < v1.29.0-0",
       "catalog.cattle.io/display-name": "Krum Platform Tools: App Launcher",
-      "catalog.cattle.io/ui-version": ">= 2.7.2"
+      "catalog.cattle.io/ui-version": ">= 2.7.2 < v2.9.0-0"
     }
   },
   "icon": "https://raw.githubusercontent.com/krumIO/krum-rancher-extensions/main/pkg/app-launcher/icon.svg",

--- a/pkg/app-launcher/pages/index.vue
+++ b/pkg/app-launcher/pages/index.vue
@@ -342,7 +342,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-@import "@shell/assets/styles/fonts/_icons.scss";
 
 .main-container {
   margin-top: -2.425rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,10 +2978,10 @@
   dependencies:
     lodash.debounce "4.0.8"
 
-"@rancher/shell@0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.5.2.tgz#ab11c8aa03001ba36734ec94f333d48f56846cdd"
-  integrity sha512-u48zCEhimZKh7WIJDGo7dLbkIV/PbRUE88/hkiQ1+xi5gZRgqO/rFCfiALzJKl35d7cCTXqWNodJnTpvwRn8JA==
+"@rancher/shell@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.5.3.tgz#4cf97b5b4992fcd0c008169bdfcdd778db9bdac2"
+  integrity sha512-/CogLZYw/k63Wn0Y6TI8CmBvKDPKHDqJGPTRK/+B6CBNimmPKCWedqeCi9IjJzk1Exj2Lv0e3csjgbK/TUaXFg==
   dependencies:
     "@aws-sdk/client-ec2" "3.1.0"
     "@aws-sdk/client-eks" "3.1.0"


### PR DESCRIPTION
The icon imports were causing minified icons files to be imported at runtime.
I believe the minified icons files may have been causing aliases to be overwritten, which could have caused the wrong icons from being selected.